### PR TITLE
Bugfix: correct copy-webpack-plugin options for Windows systems

### DIFF
--- a/packages/toolkit/src/configurations/webpack4/core.ts
+++ b/packages/toolkit/src/configurations/webpack4/core.ts
@@ -111,9 +111,13 @@ export const getCoreConfiguration = ({
         {
           from: publicFolder, // Copy all public assets (manifests, favicons, splash etc.)
           to: buildFolder,
+          // https://github.com/mrmlnc/fast-glob#pattern-syntax
+          // Only use posix paths ("/") in here, in all systems.
           globOptions: {
             ignore: [
-              path.resolve(publicFolder, 'index.html'), // Do not copy, it would be injected by HtmlWebpackPlugin
+              // Do not copy the index.html template: HtmlWebpackPlugin
+              // will generate an index referencing the webpack assets.
+              '**/index.html',
             ],
           },
         },


### PR DESCRIPTION
- fix(toolkit): correct copy-webpack-plugin globOptions for Windows
  - the underlying "fast-glob" package only accepts posix paths. Native path.resolve on windows create
paths with backslash separators, causing this "ignore" pattern not working, and the index.html
template then overwrites the HtmlWebpackPlugin generated one