### PR TITLE
Security: lock version of colors to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "ts-jest": "^27.1.0",
     "typescript": "^4.5.0"
   },
+  "resolutions": {
+    "colors": "1.4.0"
+  },
   "workspaces": [
     "examples/*",
     "packages/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,6 +1590,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@humblebee/ui-react@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@humblebee/ui-react/-/ui-react-0.2.0.tgz#3069b927eccf9570b213e47566c6e540719db302"
+  integrity sha512-cU5ztje5HXEDsj8P8hleMA1DzhVncyETl24jQqBfXQtgl/X8BHPfF29R9hLKEbXR/HZJUVimg5fy/Ldv9OnRVg==
+
 "@hutson/parse-repository-url@^3.0.0":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
@@ -6662,7 +6667,7 @@ colorette@^2.0.10, colorette@^2.0.14, colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.16.tgz#713b9af84fdb000139f04546bd4a93f62a5085da"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==


### PR DESCRIPTION
- build(dependencies): lock version of transitive dependency 'colors' to 1.4.0